### PR TITLE
Single segment fix

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject breeze-quiescent "0.1.8-SNAPSHOT"
+(defproject com.breezeehr/quiescent "0.2.0-SNAPSHOT"
   :description "A minimal, functional ClojureScript wrapper for ReactJS"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/src/breeze/quiescent.clj
+++ b/src/breeze/quiescent.clj
@@ -1,4 +1,4 @@
-(ns quiescent)
+(ns breeze.quiescent)
 
 (defmacro defcomponent
   "Creates a ReactJS component with the given name, an (optional)
@@ -16,7 +16,7 @@
         m (meta name)
         m (if (contains? m :displayName) m (assoc m :displayName (str name)))
         m (if has-docstr? (assoc m :doc docstr) m)]
-    `(def ~name ~docstr (quiescent/component
+    `(def ~name ~docstr (breeze.quiescent/component
                           (with-meta (fn ~argvec ~@body) ~m)))))
 
 (defmacro wrapped-lifecycle-method
@@ -25,7 +25,7 @@
   `(fn []
      (let [~'this (cljs.core/js-this)
            ~'args (cljs.core/js-arguments)]                 ; Bound for the body!
-       (binding [quiescent/*component* ~'this]
+       (binding [breeze.quiescent/*component* ~'this]
          ~@body))))
 
 (defmacro createMixin [& proto+specs]

--- a/src/breeze/quiescent.cljs
+++ b/src/breeze/quiescent.cljs
@@ -1,7 +1,7 @@
-(ns quiescent
+(ns breeze.quiescent
   (:require cljsjs.react
             [goog.object :as gobj])
-  (:require-macros [quiescent :as q :refer [wrapped-lifecycle-method]]))
+  (:require-macros [breeze.quiescent :as q :refer [wrapped-lifecycle-method]]))
 
 (def ^:dynamic *component*
   "Within a component render function, will be bound to the raw

--- a/src/breeze/quiescent/dom.clj
+++ b/src/breeze/quiescent/dom.clj
@@ -12,18 +12,18 @@
        ([]
          (~f nil))
        ([~'attrs]
-         (~f (quiescent.dom/js-props ~'attrs)))
+         (~f (breeze.quiescent.dom/js-props ~'attrs)))
        ([~'attrs ~'c]
-         (~f (quiescent.dom/js-props ~'attrs) ~'c))
+         (~f (breeze.quiescent.dom/js-props ~'attrs) ~'c))
        ([~'attrs ~'c1 ~'c2]
-         (~f (quiescent.dom/js-props ~'attrs) ~'c1 ~'c2))
+         (~f (breeze.quiescent.dom/js-props ~'attrs) ~'c1 ~'c2))
        ([~'attrs ~'c1 ~'c2 ~'c3]
-         (~f (quiescent.dom/js-props ~'attrs) ~'c1 ~'c2 ~'c3))
+         (~f (breeze.quiescent.dom/js-props ~'attrs) ~'c1 ~'c2 ~'c3))
        ([~'attrs ~'c1 ~'c2 ~'c3 ~'c4]
-         (~f (quiescent.dom/js-props ~'attrs) ~'c1 ~'c2 ~'c3 ~'c4))
+         (~f (breeze.quiescent.dom/js-props ~'attrs) ~'c1 ~'c2 ~'c3 ~'c4))
        ([~'attrs ~'c1 ~'c2 ~'c3 ~'c4 ~'c5 & ~'children]
          (let [a# (cljs.core/make-array 6)]
-           (aset a# 0 (quiescent.dom/js-props ~'attrs))
+           (aset a# 0 (breeze.quiescent.dom/js-props ~'attrs))
            (aset a# 1 ~'c1)
            (aset a# 2 ~'c2)
            (aset a# 3 ~'c3)
@@ -38,7 +38,7 @@
       (nil? attrs) nil
       (instance? JSValue attrs) attrs
       (map? attrs) (cljs.tagged-literals/read-js attrs)
-      :else (list 'quiescent.dom/js-props attrs))))
+      :else (list 'breeze.quiescent.dom/js-props attrs))))
 
 (defmacro ^:private tag-macro*
   "Define a macro which calls a React.DOM factory."

--- a/src/breeze/quiescent/dom.clj
+++ b/src/breeze/quiescent/dom.clj
@@ -1,4 +1,4 @@
-(ns quiescent.dom
+(ns breeze.quiescent.dom
   (:refer-clojure :exclude [map meta time])
   (:require cljs.tagged-literals)
   (:import (cljs.tagged_literals JSValue)))

--- a/src/breeze/quiescent/dom.cljs
+++ b/src/breeze/quiescent/dom.cljs
@@ -1,6 +1,6 @@
-(ns quiescent.dom
+(ns breeze.quiescent.dom
   (:refer-clojure :exclude [map mask meta time])
-  (:require-macros [quiescent.dom :as dm])
+  (:require-macros [breeze.quiescent.dom :as dm])
   (:require cljsjs.react
             cljsjs.react.dom
             [goog.object :as gobj]))


### PR DESCRIPTION
Recent versions of clojurescript issue warnings with single segment namespaces (in this case `quiescent`). so move them to `breeze.quiescent`. Figwheel-main was having a terrible issue with this and giving a strange error

> file:/home/dan/.m2/repository/breeze-quiescent/breeze-quiescent/0.1.8-SNAPSHOT/breeze-quiescent-0.1.8-SNAPSHOT.jar!/quiescent.cljs